### PR TITLE
docs: fix branding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GrammY Telegraph Plugin
+# grammY Telegraph Plugin
 ## Work-in-progress
 
 ## Installing


### PR DESCRIPTION
It's grammY not GrammY